### PR TITLE
Small optimization

### DIFF
--- a/src/dpp/dpp_iter.m
+++ b/src/dpp/dpp_iter.m
@@ -5,7 +5,7 @@ function [cliq_and_plex1, communities1, cliq_and_plex2, communities2, dyn_commun
 %   community.
 
 % reuse previous calculations
-if ~exist('cliq1', 'var')
+if ~exist('cliq_and_plex1', 'var')
     [cliq_and_plex1, communities1] = dpp_single(a1, k, m);
 end
 

--- a/src/dpp/dpp_single.m
+++ b/src/dpp/dpp_single.m
@@ -77,6 +77,12 @@ for i = 1:(num_cliq_and_plex-1)
     % remaining cliques/plexes
     js = (i+1):num_cliq_and_plex;
     
+    % optimization: only consider those that are not already part of the same community
+    js = js(communities(js) ~= communities(i));
+    if isempty(js)
+        continue;
+    end
+    
     % vector of overlaps between remaining cliques/plexes and clique/plex i
     overlap = sum(cliq_and_plex(js, cliq_and_plex(i, :)), 2);
     


### PR DESCRIPTION
Calculating cliques and plex overlap is one of the slowest steps in `dpp_single`. This optimization calculates overlap only for those cliques and plexes that are not already merged into a single community.

Closes #3.

(Will post benchmarking details.)